### PR TITLE
use latest vxcontrol/vxbuild-cross for building agent

### DIFF
--- a/build/package/agent/build-vxbuild.sh
+++ b/build/package/agent/build-vxbuild.sh
@@ -8,4 +8,4 @@ docker run --rm -it \
         -v $(realpath "$SCRIPT_DIR/../../../../"):/go/src/ \
         -v $(go env GOMODCACHE):/go/pkg/mod \
         --workdir=/go/src/soldr \
-        vxcontrol/vxbuild-cross:1.19.1 /bin/bash -c "build/package/agent/build-$(go env GOOS)-$(go env GOARCH).sh"
+        vxcontrol/vxbuild-cross:latest /bin/bash -c "build/package/agent/build-$(go env GOOS)-$(go env GOARCH).sh"

--- a/build/package/api/build-vxbuild.sh
+++ b/build/package/api/build-vxbuild.sh
@@ -8,4 +8,4 @@ docker run --rm -it \
         -v $(realpath "$SCRIPT_DIR/../../../../"):/go/src/ \
         -v $(go env GOMODCACHE):/go/pkg/mod \
         --workdir=/go/src/soldr \
-        vxcontrol/vxbuild-cross:1.19.1 /bin/bash -c "build/package/server/build-local.sh"
+        vxcontrol/vxbuild-cross:latest /bin/bash -c "build/package/server/build-local.sh"

--- a/build/package/server/build-vxbuild.sh
+++ b/build/package/server/build-vxbuild.sh
@@ -8,4 +8,4 @@ docker run --rm -it \
         -v $(realpath "$SCRIPT_DIR/../../../../"):/go/src/ \
         -v $(go env GOMODCACHE):/go/pkg/mod \
         --workdir=/go/src/soldr \
-        vxcontrol/vxbuild-cross:1.19.1 /bin/bash -c "build/package/server/build-$(go env GOOS)-$(go env GOARCH).sh"
+        vxcontrol/vxbuild-cross:latest /bin/bash -c "build/package/server/build-$(go env GOOS)-$(go env GOARCH).sh"


### PR DESCRIPTION
The `vxcontrol/vxbuild-cross:1.19.1` has no jq (JSON processor) for correct executing build scripts. The `latest` tag fix this problem.