### PR TITLE
Fix escaping in make target: setup-web-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ generate-keys:
 
 .PHONY: setup-web-proxy
 setup-web-proxy:
-	echo "{\n  \"/api\": {\n    \"target\": \"http://localhost\",\n    \"secure\": false\n  }\n}" > $(CURDIR)/web/proxy.conf.json
+	echo '{"api": {"target": "http://localhost", "secure": false}}' > web/proxy.conf.json
 
 .PHONY: db-init
 db-init: db-create db-seed

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ generate-keys:
 
 .PHONY: setup-web-proxy
 setup-web-proxy:
-	echo '{"api": {"target": "http://localhost", "secure": false}}' > web/proxy.conf.json
+	echo '{"api": {"target": "http://localhost", "secure": false}}' > $(CURDIR)/web/proxy.conf.json
 
 .PHONY: db-init
 db-init: db-create db-seed


### PR DESCRIPTION
Before the fix it produced a wrong json:
```
$ make setup-web-proxy
echo "{\n  \"/api\": {\n    \"target\": \"http://localhost\",\n    \"secure\": false\n  }\n}" > /home/souz9/cyberok/soldr/web/proxy.conf.json
$ cat web/proxy.conf.json
{\n  "/api": {\n    "target": "http://localhost",\n    "secure": false\n  }\n}
```