### PR TITLE
fix(ui): allow spaces in localization values in system module (#32)

### DIFF
--- a/web/libs/features/modules/src/lib/components/edit-localization-section/edit-localization-section.component.html
+++ b/web/libs/features/modules/src/lib/components/edit-localization-section/edit-localization-section.component.html
@@ -22,7 +22,7 @@
                                                 {{ t('Modules.ModuleEdit.Label.Title') }} *
                                             </label>
                                             <mc-form-field class="mc-form__control">
-                                                <input e2e-id="txtModuleTitleLocale" mcInput formControlName="title">
+                                                <input e2e-id="txtModuleTitleLocale" mcInput formControlName="title" no-trim>
                                             </mc-form-field>
                                         </div>
 
@@ -31,7 +31,7 @@
                                                 {{ t('Modules.ModuleEdit.Label.Description')}}
                                             </label>
                                             <mc-form-field class="mc-form__control">
-                                                <input e2e-id="txtModuleDescriptionLocale" mcInput formControlName="description">
+                                                <input e2e-id="txtModuleDescriptionLocale" mcInput formControlName="description" no-trim>
                                             </mc-form-field>
                                         </div>
                                     </div>
@@ -69,7 +69,8 @@
                                                         <input
                                                             e2e-id="txtConfigParamTitleLocale"
                                                             mcInput
-                                                            formControlName="title">
+                                                            formControlName="title"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
 
@@ -81,7 +82,8 @@
                                                         <input
                                                             e2e-id="txtConfigParamDescriptionLocale"
                                                             mcInput
-                                                            formControlName="description">
+                                                            formControlName="description"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
                                             </div>
@@ -122,7 +124,8 @@
                                                         <input
                                                             e2e-id="txtSecureConfigParamTitleLocale"
                                                             mcInput
-                                                            formControlName="title">
+                                                            formControlName="title"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
 
@@ -134,7 +137,8 @@
                                                         <input
                                                             e2e-id="txtSecureConfigParamDescriptionLocale"
                                                             mcInput
-                                                            formControlName="description">
+                                                            formControlName="description"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
                                             </div>
@@ -175,7 +179,8 @@
                                                         <input
                                                             e2e-id="txtEventTitleLocale"
                                                             mcInput
-                                                            formControlName="title">
+                                                            formControlName="title"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
 
@@ -187,7 +192,8 @@
                                                         <input
                                                             e2e-id="txtEventDescriptionLocale"
                                                             mcInput
-                                                            formControlName="description">
+                                                            formControlName="description"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
                                             </div>
@@ -236,7 +242,8 @@
                                                                     <input
                                                                         e2e-id="txtEventConfigKeyTitleLocale"
                                                                         mcInput
-                                                                        formControlName="title">
+                                                                        formControlName="title"
+                                                                        no-trim>
                                                                 </mc-form-field>
                                                             </div>
 
@@ -248,7 +255,8 @@
                                                                     <input
                                                                         e2e-id="txtEventConfigKeyDescriptionLocale"
                                                                         mcInput
-                                                                        formControlName="description">
+                                                                        formControlName="description"
+                                                                        no-trim>
                                                                 </mc-form-field>
                                                             </div>
                                                         </div>
@@ -292,7 +300,8 @@
                                                         <input
                                                             e2e-id="txtActionTitleLocale"
                                                             mcInput
-                                                            formControlName="title">
+                                                            formControlName="title"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
 
@@ -304,7 +313,8 @@
                                                         <input
                                                             e2e-id="txtActionDescriptionLocale"
                                                             mcInput
-                                                            formControlName="description">
+                                                            formControlName="description"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
                                             </div>
@@ -353,7 +363,8 @@
                                                                     <input
                                                                         e2e-id="txtActionConfigKeyTitleLocale"
                                                                         mcInput
-                                                                        formControlName="title">
+                                                                        formControlName="title"
+                                                                        no-trim>
                                                                 </mc-form-field>
                                                             </div>
 
@@ -365,7 +376,8 @@
                                                                     <input
                                                                         e2e-id="txtActionConfigKeyDescriptionLocale"
                                                                         mcInput
-                                                                        formControlName="description">
+                                                                        formControlName="description"
+                                                                        no-trim>
                                                                 </mc-form-field>
                                                             </div>
                                                         </div>
@@ -409,7 +421,8 @@
                                                         <input
                                                             e2e-id="txtFieldTitleLocale"
                                                             mcInput
-                                                            formControlName="title">
+                                                            formControlName="title"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
 
@@ -421,7 +434,8 @@
                                                         <input
                                                             e2e-id="txtFieldDescriptionLocale"
                                                             mcInput
-                                                            formControlName="description">
+                                                            formControlName="description"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
                                             </div>
@@ -462,7 +476,8 @@
                                                         <input
                                                             e2e-id="txtTagTitleLocale"
                                                             mcInput
-                                                            formControlName="title">
+                                                            formControlName="title"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
 
@@ -474,7 +489,8 @@
                                                         <input
                                                             e2e-id="txtTagDescriptionLocale"
                                                             mcInput
-                                                            formControlName="description">
+                                                            formControlName="description"
+                                                            no-trim>
                                                     </mc-form-field>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Alow spaces in localization values in system module when editing