### PR TITLE
Add vxproto subscriptions (topics)

### DIFF
--- a/internal/lua/module.go
+++ b/internal/lua/module.go
@@ -298,11 +298,13 @@ func (m *Module) getIMCTokenInfo(token string) (string, string, bool) {
 }
 
 func (m *Module) isIMCTokenExist(token string) bool {
-	return m.socket.GetIMCModule(token) != nil
-}
-
-func (m *Module) isIMCTopicExist(topic string) bool {
-	return m.socket.GetIMCTopic(topic) != nil
+	if m.socket.HasIMCTokenFormat(token) {
+		return m.socket.GetIMCModule(token) != nil
+	}
+	if m.socket.HasIMCTopicFormat(token) {
+		return m.socket.GetIMCTopic(token) != nil
+	}
+	return false
 }
 
 func (m *Module) makeIMCToken(name, gid string) string {
@@ -1486,7 +1488,6 @@ func NewModule(args map[string][]string, state *State, socket vxproto.IModuleSoc
 		"get_token":                   m.getIMCToken,
 		"get_info":                    m.getIMCTokenInfo,
 		"is_exist":                    m.isIMCTokenExist,
-		"is_topic":                    m.isIMCTopicExist,
 		"make_token":                  m.makeIMCToken,
 		"make_topic":                  m.makeIMCTopic,
 		"subscribe_to_topic":          m.subscribeIMCToTopic,

--- a/internal/lua/module.go
+++ b/internal/lua/module.go
@@ -329,7 +329,7 @@ func (m *Module) getIMCSubscriptions(topic string) []string {
 	if info := m.socket.GetIMCTopic(topic); info != nil {
 		return info.GetSubscriptions()
 	}
-	return make([]string, 0)
+	return []string{}
 }
 
 func (m *Module) getIMCTopics() []string {
@@ -400,6 +400,9 @@ func (m *Module) tryPacketUnlock(dst string) {
 }
 
 func (m *Module) filterVXProtoErrors(err error) bool {
+	// to decrease errors rate because these errors are systematic
+	// e.g. topic is creating since first subscribe so
+	// while there are nothing subscribers all api send_* calls raise the error
 	return errors.Is(err, vxproto.ErrTopicUnreachable)
 }
 

--- a/internal/lua/module_test.go
+++ b/internal/lua/module_test.go
@@ -492,7 +492,7 @@ func Example_topics_api() {
 			end
 
 			-- check topic information
-			assert(__imc.is_topic(topic_token))
+			assert(__imc.is_exist(topic_token))
 			local name, gid, exist = __imc.get_info(topic_token)
 			assert(name == topic_name and gid == __gid and exist)
 
@@ -1037,7 +1037,7 @@ func TestIMCSendDataToTopic(t *testing.T) {
 	sender := []byte(`
 		__api.await(200)
 		local imc_topic = __imc.make_topic(__args["dst_module"][1], "")
-		if __imc.is_topic(imc_topic) == false then
+		if __imc.is_exist(imc_topic) == false then
 			return result
 		end
 		local topicName, groupID, isExist = __imc.get_info(imc_topic)

--- a/internal/vxproto/proto.go
+++ b/internal/vxproto/proto.go
@@ -124,7 +124,7 @@ type IIMC interface {
 	GetIMCModuleIDsByGID(gid string) []string
 }
 
-// ITopicInfo is interface for describe topic registration per each record
+// ITopicInfo is an interface for an object that can give topic registration information
 type ITopicInfo interface {
 	GetName() string
 	GetGroupID() string
@@ -850,22 +850,14 @@ func (vxp *vxProto) NewToken(agentID string, agentType AgentType) (string, error
 	return token, nil
 }
 
-// HasIMCTokenFormat is function which validate imc token format
+// HasIMCTokenFormat is a IMC token format validation function
 func (vxp *vxProto) HasIMCTokenFormat(token string) bool {
-	if len(token) != 40 || !strings.HasPrefix(token, "ffffffff") {
-		return false
-	}
-
-	return true
+	return len(token) == 40 && strings.HasPrefix(token, "ffffffff")
 }
 
-// HasIMCTopicFormat is function which validate imc topic format
+// HasIMCTopicFormat is a IMC topic format validation function
 func (vxp *vxProto) HasIMCTopicFormat(topic string) bool {
-	if len(topic) != 40 || !strings.HasPrefix(topic, "ffff7777") {
-		return false
-	}
-
-	return true
+	return len(topic) == 40 && strings.HasPrefix(topic, "ffff7777")
 }
 
 // GetIMCModule is function which get module socket for imc token
@@ -906,19 +898,19 @@ func (vxp *vxProto) GetIMCTopic(topic string) ITopicInfo {
 	return nil
 }
 
-// MakeIMCToken is function which get new imc token
+// MakeIMCToken generates new IMC token
 func (vxp *vxProto) MakeIMCToken(name, gid string) string {
 	hash := md5.Sum(append([]byte(gid+":"+name+":"), vxp.tokenKey...))
 	return "ffffffff" + hex.EncodeToString(hash[:])
 }
 
-// MakeIMCTopic is function which get new imc topic
+// MakeIMCTopic generates new IMC topic
 func (vxp *vxProto) MakeIMCTopic(name, gid string) string {
 	hash := md5.Sum(append([]byte(gid+":"+name+":"), vxp.tokenKey...))
 	return "ffff7777" + hex.EncodeToString(hash[:])
 }
 
-// SubscribeIMCToTopic is function to make or extend record about topic in vxproto
+// SubscribeIMCToTopic appends IMC topic subscription if it is not registered yet
 func (vxp *vxProto) SubscribeIMCToTopic(name, gid, token string) bool {
 	if !vxp.HasIMCTokenFormat(token) {
 		return false
@@ -943,7 +935,7 @@ func (vxp *vxProto) SubscribeIMCToTopic(name, gid, token string) bool {
 	return true
 }
 
-// UnsubscribeIMCFromTopic is function to remove record about topic in vxproto
+// UnsubscribeIMCFromTopic removes IMC topic subscription
 func (vxp *vxProto) UnsubscribeIMCFromTopic(name, gid, token string) bool {
 	if !vxp.HasIMCTokenFormat(token) {
 		return false
@@ -972,7 +964,7 @@ func (vxp *vxProto) UnsubscribeIMCFromTopic(name, gid, token string) bool {
 	return true
 }
 
-// UnsubscribeIMCFromAllTopics is function to remove all topic records by imc token
+// UnsubscribeIMCFromAllTopics removes all topic records for IMC token
 func (vxp *vxProto) UnsubscribeIMCFromAllTopics(token string) bool {
 	if !vxp.HasIMCTokenFormat(token) {
 		return false
@@ -1009,7 +1001,7 @@ func (vxp *vxProto) unsubscribeIMCFromAllTopics(token string) {
 	}
 }
 
-// GetIMCTopics is function to get all registered topic IDs from vxproto
+// GetIMCTopics returns all registered IMC topics identifiers
 func (vxp *vxProto) GetIMCTopics() []string {
 	vxp.mutex.RLock()
 	defer vxp.mutex.RUnlock()

--- a/internal/vxproto/proto_test.go
+++ b/internal/vxproto/proto_test.go
@@ -1687,7 +1687,7 @@ func TestIMCTopicsAPI(t *testing.T) {
 			t.Fatal("failed to prepare topic token")
 		}
 
-		// On publisher side: check is topic available
+		// On publisher side: check topic availability
 		if tokenInfo := moduleSocket.GetIMCTopic(topicToken); tokenInfo != nil {
 			// This topic doesn't contain any subscribers and doesn't register in VXProto
 			t.Fatal("unregistered topic must return nil as an info")
@@ -1696,17 +1696,17 @@ func TestIMCTopicsAPI(t *testing.T) {
 		// On publisher side: test sending packet to unavailable topic
 		err := moduleSocket.SendDataTo(ctx, topicToken, &Data{Data: testData})
 		if !errors.Is(err, ErrTopicUnreachable) {
-			// This call to send any packets to unavailable topic must raise the error
+			// Sending a packet to unavailable topic must raise ErrTopicUnreachable error
 			t.Fatal("send data call returned unexpected error", err)
 		}
 
-		// On subscriber side: subsribe to the topic and add an IMC token to the list
+		// On subscriber side: subscribe to the topic and add an IMC token to the list
 		if !moduleSocket.SubscribeIMCToTopic(topicName, groupID, imcToken) {
-			// This topic was unregistered and must be free to subscribe on it
-			t.Fatal("unregistered topic must be available to subsribing")
+			// Subscription to an unregistered topic should succeed
+			t.Fatal("unregistered topic must be available to subscribing")
 		}
 
-		// On publisher side: double check is topic available
+		// On publisher side: double check that topic is available
 		if topicInfoR := moduleSocket.GetIMCTopic(topicToken); topicInfoR == nil {
 			// This topic must be registered in VXProto after previosly SubscribeIMC* call
 			t.Fatal("registered topic must return info about itself")
@@ -1718,7 +1718,7 @@ func TestIMCTopicsAPI(t *testing.T) {
 			t.Fatal("registered topic must contain IMC token which was added")
 		}
 
-		// On subscriber side: run routine to receive an packet
+		// On subscriber side: run routine to receive a packet
 		go func() {
 			src, data, err := moduleSocket.RecvData(ctx, 1000)
 			if err != nil || src != imcToken || !bytes.Equal(data.Data, testData) {
@@ -1726,25 +1726,25 @@ func TestIMCTopicsAPI(t *testing.T) {
 			}
 		}()
 
-		// On publisher side: test sending packet to available topic
+		// On publisher side: test sending packet to a available topic
 		if err := moduleSocket.SendDataTo(ctx, topicToken, &Data{Data: testData}); err != nil {
-			// This call to send any packets to available topic must not raise an error
+			// Sending packets to a registered topics should not raise any errors
 			t.Fatal("send data call returned an error", err)
 		}
 
 		// On subscriber side: unsubscribe from the topic and delete an IMC token from the list
 		if !moduleSocket.UnsubscribeIMCFromTopic(topicName, groupID, imcToken) {
-			t.Fatal("registered topic must be available to unsubscribing")
+			t.Fatal("registered topic must be available for unsubscribing")
 		}
 	}
 
 	if len(proto.GetIMCTopics()) != 0 {
-		t.Fatal("registered topics list must be empty after each was unsubscribed")
+		t.Fatal("registered topics list must be empty once everyone got unsubscribed")
 	}
 
-	// Just it checks API while there is nothing to unsubscribe
+	// Check an API when there are nothing to unsubscribe
 	if !moduleSocket.UnsubscribeIMCFromAllTopics(imcToken) {
-		t.Fatal("registered topic must be available to unsubscribing")
+		t.Fatal("failed to unsubscribe while there should be no subscriptions")
 	}
 }
 

--- a/internal/vxproto/proto_test.go
+++ b/internal/vxproto/proto_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1470,6 +1471,134 @@ func TestIMCSendRecvPackets(t *testing.T) {
 	wg.Wait()
 }
 
+func TestIMCSendRecvPacketsToTopic(t *testing.T) {
+	ctx := context.Background()
+	proto, err := getVXProto()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proto.Close(ctx)
+
+	topicName := "test_topic"
+	topicToken := proto.MakeIMCTopic(topicName, groupID)
+	module1Token := proto.MakeIMCToken("test1", groupID)
+	moduleSocket1 := proto.NewModule("test1", groupID)
+	if moduleSocket1 != nil {
+		if !proto.AddModule(moduleSocket1) {
+			t.Fatal("failed to add sender Module Socket object")
+		}
+	} else {
+		t.Fatal("failed to initialize sender Module Socket object")
+	}
+	defer func() {
+		if !proto.DelModule(moduleSocket1) {
+			t.Fatal("failed to delete sender Module Socket object")
+		}
+	}()
+
+	receivers := make([]IModuleSocket, 0)
+	for idx := 0; idx < 5; idx++ {
+		moduleID := fmt.Sprintf("test%d", idx+2)
+		moduleSocket := proto.NewModule(moduleID, groupID)
+		if moduleSocket != nil {
+			if !proto.AddModule(moduleSocket) {
+				t.Fatalf("failed to add receiver[%d] Module Socket object", idx)
+			}
+		} else {
+			t.Fatalf("failed to initialize receiver[%d] Module Socket object", idx)
+		}
+		defer func() {
+			if !proto.DelModule(moduleSocket) {
+				t.Fatalf("failed to delete receiver[%d] Module Socket object", idx)
+			}
+		}()
+		if !moduleSocket.SubscribeIMCToTopic(topicName, groupID, moduleSocket.GetIMCToken()) {
+			t.Fatalf("failed to subscribe receiver[%d] Module Socket object to topic", idx)
+		}
+		receivers = append(receivers, moduleSocket)
+	}
+
+	var wg sync.WaitGroup
+	testData := []byte("test data message")
+	actName := "test_action_name"
+	textName := "test_text_name"
+	fileName := "test_file_name.tmp"
+	msgType := MTDebug
+	recvSyncChan := make(chan struct{})
+
+	batchReceive := func(ms IModuleSocket, src, dst string) {
+		checkRoutingInfo := func(packet *Packet) {
+			if packet.Src != src || packet.Dst != dst {
+				t.Fatal("failed to routing info of received packet on " + ms.GetName())
+			}
+		}
+
+		var packet *Packet
+		packet = <-ms.GetReceiver()
+		if !bytes.Equal(packet.GetData().Data, testData) {
+			t.Fatal("failed to compare of received data on " + ms.GetName())
+		}
+		packet.SetAck()
+		checkRoutingInfo(packet)
+		packet = <-ms.GetReceiver()
+		if !bytes.Equal(packet.GetText().Data, testData) || packet.GetText().Name != textName {
+			t.Fatal("failed to compare of received text on " + ms.GetName())
+		}
+		packet.SetAck()
+		checkRoutingInfo(packet)
+		packet = <-ms.GetReceiver()
+		if !checkFileData(packet.GetFile().Path, testData) || packet.GetFile().Name != fileName || packet.GetFile().Data != nil {
+			t.Fatal("failed to compare of received file on " + ms.GetName())
+		}
+		packet.SetAck()
+		checkRoutingInfo(packet)
+		packet = <-ms.GetReceiver()
+		if !bytes.Equal(packet.GetMsg().Data, testData) || packet.GetMsg().MType != msgType {
+			t.Fatal("failed to compare of received message on " + ms.GetName())
+		}
+		packet.SetAck()
+		checkRoutingInfo(packet)
+		packet = <-ms.GetReceiver()
+		if !bytes.Equal(packet.GetAction().Data, testData) || packet.GetAction().Name != actName {
+			t.Fatal("failed to compare of received action on " + ms.GetName())
+		}
+		packet.SetAck()
+		checkRoutingInfo(packet)
+	}
+
+	batchSend := func(ms IModuleSocket, dst string) {
+		if err := ms.SendDataTo(ctx, dst, &Data{Data: testData}); err != nil {
+			t.Fatal("failed to send data packet to modude via imc:", err.Error())
+		}
+		if err := ms.SendTextTo(ctx, dst, &Text{Data: testData, Name: textName}); err != nil {
+			t.Fatal("failed to send text packet to modude via imc:", err.Error())
+		}
+		if err := ms.SendFileTo(ctx, dst, &File{Data: testData, Name: fileName, Path: ""}); err != nil {
+			t.Fatal("failed to send file packet to modude via imc:", err.Error())
+		}
+		if err := ms.SendMsgTo(ctx, dst, &Msg{Data: testData, MType: msgType}); err != nil {
+			t.Fatal("failed to send message packet to modude via imc:", err.Error())
+		}
+		if err := ms.SendActionTo(ctx, dst, &Action{Data: testData, Name: actName}); err != nil {
+			t.Fatal("failed to send action packet to modude via imc:", err.Error())
+		}
+	}
+
+	for _, mod := range receivers {
+		wg.Add(1)
+		go func(module IModuleSocket) {
+			defer wg.Done()
+			<-recvSyncChan
+			batchReceive(module, module1Token, topicToken)
+		}(mod)
+	}
+
+	close(recvSyncChan)
+	batchSend(moduleSocket1, topicToken)
+
+	wg.Wait()
+}
+
 func TestIMCSendToUnknownDestination(t *testing.T) {
 	ctx := context.Background()
 	proto, err := getVXProto()
@@ -1481,34 +1610,141 @@ func TestIMCSendToUnknownDestination(t *testing.T) {
 	moduleSocket := proto.NewModule("test", groupID)
 	if moduleSocket != nil {
 		if !proto.AddModule(moduleSocket) {
-			t.Fatal("Failed add Module Socket object")
+			t.Fatal("failed to add Module Socket object")
 		}
 	} else {
-		t.Fatal("Failed initialize Module Socket object")
+		t.Fatal("failed to initialize Module Socket object")
 	}
 	defer func() {
 		if !proto.DelModule(moduleSocket) {
-			t.Fatal("Failed delete Module Socket object")
+			t.Fatal("failed to delete Module Socket object")
 		}
 	}()
 
+	type destination struct {
+		token  string
+		expect error
+	}
+	dsts := []destination{
+		{proto.MakeIMCToken("unknown", groupID), ErrDstUnreachable},
+		{proto.MakeIMCTopic("unknown", groupID), ErrTopicUnreachable},
+	}
 	testData := []byte("test data message")
 	textName := "test_text_name"
 	fileName := "test_file_name.tmp"
 	msgType := MTDebug
-	dst := proto.MakeIMCToken("unknown", agentID)
 
-	if err := moduleSocket.SendDataTo(ctx, dst, &Data{Data: testData}); err == nil {
-		t.Fatal("Failed send data packet to modude via imc:", err.Error())
+	for _, d := range dsts {
+		dst := d.token
+		err := moduleSocket.SendDataTo(ctx, dst, &Data{Data: testData})
+		if !errors.Is(err, d.expect) {
+			t.Fatal("failed to send data packet to modude via imc", err)
+		}
+		err = moduleSocket.SendTextTo(ctx, dst, &Text{Data: testData, Name: textName})
+		if !errors.Is(err, d.expect) {
+			t.Fatal("failed to send text packet to modude via imc", err)
+		}
+		err = moduleSocket.SendFileTo(ctx, dst, &File{Data: testData, Name: fileName, Path: ""})
+		if !errors.Is(err, d.expect) {
+			t.Fatal("failed to send file packet to modude via imc", err)
+		}
+		err = moduleSocket.SendMsgTo(ctx, dst, &Msg{Data: testData, MType: msgType})
+		if !errors.Is(err, d.expect) {
+			t.Fatal("failed to send message packet to modude via imc", err)
+		}
 	}
-	if err := moduleSocket.SendTextTo(ctx, dst, &Text{Data: testData, Name: textName}); err == nil {
-		t.Fatal("Failed send text packet to modude via imc:", err.Error())
+}
+
+func TestIMCTopicsAPI(t *testing.T) {
+	ctx := context.Background()
+	proto, err := getVXProto()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := moduleSocket.SendFileTo(ctx, dst, &File{Data: testData, Name: fileName, Path: ""}); err == nil {
-		t.Fatal("Failed send file packet to modude via imc:", err.Error())
+	defer proto.Close(ctx)
+
+	moduleSocket := proto.NewModule("test", groupID)
+	if moduleSocket != nil {
+		if !proto.AddModule(moduleSocket) {
+			t.Fatal("failed to add Module Socket object")
+		}
+	} else {
+		t.Fatal("failed to initialize Module Socket object")
 	}
-	if err := moduleSocket.SendMsgTo(ctx, dst, &Msg{Data: testData, MType: msgType}); err == nil {
-		t.Fatal("Failed send message packet to modude via imc:", err.Error())
+	defer func() {
+		if !proto.DelModule(moduleSocket) {
+			t.Fatal("failed to delete Module Socket object")
+		}
+	}()
+
+	imcToken := moduleSocket.GetIMCToken()
+	testData := []byte("test data message")
+	for idx := 0; idx < 10000; idx++ {
+		// On publisher side: should make topic token
+		topicName := fmt.Sprintf("test_topic%d", idx)
+		topicToken := moduleSocket.MakeIMCTopic(topicName, groupID)
+		if !strings.HasPrefix(topicToken, "ffff7777") {
+			t.Fatal("failed to prepare topic token")
+		}
+
+		// On publisher side: check is topic available
+		if tokenInfo := moduleSocket.GetIMCTopic(topicToken); tokenInfo != nil {
+			// This topic doesn't contain any subscribers and doesn't register in VXProto
+			t.Fatal("unregistered topic must return nil as an info")
+		}
+
+		// On publisher side: test sending packet to unavailable topic
+		err := moduleSocket.SendDataTo(ctx, topicToken, &Data{Data: testData})
+		if !errors.Is(err, ErrTopicUnreachable) {
+			// This call to send any packets to unavailable topic must raise the error
+			t.Fatal("send data call returned unexpected error", err)
+		}
+
+		// On subscriber side: subsribe to the topic and add an IMC token to the list
+		if !moduleSocket.SubscribeIMCToTopic(topicName, groupID, imcToken) {
+			// This topic was unregistered and must be free to subscribe on it
+			t.Fatal("unregistered topic must be available to subsribing")
+		}
+
+		// On publisher side: double check is topic available
+		if topicInfoR := moduleSocket.GetIMCTopic(topicToken); topicInfoR == nil {
+			// This topic must be registered in VXProto after previosly SubscribeIMC* call
+			t.Fatal("registered topic must return info about itself")
+		} else if topicInfoR.GetName() != topicName || topicInfoR.GetGroupID() != groupID {
+			// This topic contains mismatch name or group ID
+			t.Fatal("registered topic must return correct info about itself")
+		} else if !stringInSlice(imcToken, topicInfoR.GetSubscriptions()) {
+			// Current IMC token must contain in the topic subscriptions list
+			t.Fatal("registered topic must contain IMC token which was added")
+		}
+
+		// On subscriber side: run routine to receive an packet
+		go func() {
+			src, data, err := moduleSocket.RecvData(ctx, 1000)
+			if err != nil || src != imcToken || !bytes.Equal(data.Data, testData) {
+				t.Error("error reading packet from topic")
+			}
+		}()
+
+		// On publisher side: test sending packet to available topic
+		if err := moduleSocket.SendDataTo(ctx, topicToken, &Data{Data: testData}); err != nil {
+			// This call to send any packets to available topic must not raise an error
+			t.Fatal("send data call returned an error", err)
+		}
+
+		// On subscriber side: unsubscribe from the topic and delete an IMC token from the list
+		if !moduleSocket.UnsubscribeIMCFromTopic(topicName, groupID, imcToken) {
+			t.Fatal("registered topic must be available to unsubscribing")
+		}
+	}
+
+	if len(proto.GetIMCTopics()) != 0 {
+		t.Fatal("registered topics list must be empty after each was unsubscribed")
+	}
+
+	// Just it checks API while there is nothing to unsubscribe
+	if !moduleSocket.UnsubscribeIMCFromAllTopics(imcToken) {
+		t.Fatal("registered topic must be available to unsubscribing")
 	}
 }
 


### PR DESCRIPTION
### Description of the Change

These changes implement base scenario to delivery packets from one producer to multiple consumers when all modules know nothing about them. To use this delivery schema all modules developers should choose only topic name and agree JSON format to separate packets for this topic from other packets.

The most relevant case for feature is WinEventLog module which collecting events from OS and distribute it to other modules. At this moment this case solved by receiver modules name list in WinEventLog module to make IMC token for each receiver and to send events there.

Against this approach each receiver module can call API method to subscribe on the topic and to start publishing events from WinEventLog module to the topic.

### How to test the Change

Use samples from `modules_test.go` and unit tests from `proto_test.go`

### Changelog Entry

* Added new Lua IMC methods:
`__imc.is_topic(token: string) -> bool`
`__imc.make_topic(name: string, group_id: string) -> string`
`__imc.subscribe_to_topic(name: string, group_id: string) -> bool`
`__imc.unsubscribe_from_topic(name: string, group_id: string) -> bool`
`__imc.unsubscribe_from_all_topics() -> bool`
`__imc.get_topics() -> []string`
`__imc.get_subscriptions(token string) -> []string`

* Changed behaviour of `__imc.get_info(token: string) -> string, string, bool`
Now it call may return information about topic when this token will set as a first argument of the call.

* Extended VXProto internal API for IModuleSocket.

### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
