### PR TITLE
fix(ui): invalid monaco editor loader

### DIFF
--- a/web/angular.json
+++ b/web/angular.json
@@ -148,9 +148,6 @@
                             "./node_modules/monaco-editor/esm/vs/editor/browser/widget/media/diffReview.css",
                             "./node_modules/monaco-editor/esm/vs/platform/contextview/browser/contextMenuHandler.css"
                         ],
-                        "scripts": [
-                            "./node_modules/monaco-editor/min/vs/loader.js"
-                        ],
                         "stylePreprocessorOptions": {
                             "includePaths": ["node_modules"]
                         }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
When using xterm.js in the browser part of the module, the error "Terminal is not defined" is thrown.
This is due to the redundant monaco editor loader that adds `window.define.amd.jquery = true`, which causes xterm to not correctly detect module loading environments.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ x ] All new and existing tests pass.
