### PR TITLE
fix(ui): modal filter closes when the filter is reset

### DIFF
--- a/web/libs/shared/src/lib/components/grid/filter/filter.component.ts
+++ b/web/libs/shared/src/lib/components/grid/filter/filter.component.ts
@@ -187,8 +187,6 @@ export class FilterComponent implements OnInit, OnChanges, AfterContentInit {
 
     reset() {
         this.selectedFilterValues$.next([]);
-        this.changeValue.emit({ field: this.field, value: [] });
-        this.filterPopover.hide(0);
     }
 
     private sortByEnabledState(selectedValues: string[]) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
The modal filter closes when the filter is reset

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
