### PR TITLE
Add vxproto connection linked to group lua state

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
                 "LOG_DIR": "${workspaceFolder}/build/logs"
             },
             "args": ["-debug", "-profiling"], 
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/build",
             "dlvFlags": ["--check-go-version=false"],
             "preLaunchTask": "build vxserver"
         },
@@ -53,7 +53,7 @@
                 "LOG_DIR": "${workspaceFolder}/build/logs"
             },
             "args": ["-debug"], 
-            "cwd": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}/build",
             "dlvFlags": ["--check-go-version=false"],
             "preLaunchTask": "build vxagent"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -81,6 +81,21 @@
             ], 
             "cwd": "${workspaceFolder}/scripts/sbh_generator",
             "dlvFlags": ["--check-go-version=false"]
+        },
+        {
+            "name": "launch certs generator",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/scripts/certs_writer",
+            "env": {},
+            "args": [
+                "-cert_gen=true",
+                "--dst=${workspaceFolder}/scripts/certs_writer/certs/tmp_dir",
+                "--server_name=example"
+            ],
+            "cwd": "${workspaceFolder}/scripts/certs_writer",
+            "dlvFlags": ["--check-go-version=false"]
         }
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,10 @@ db-create:
 
 .PHONY: db-seed
 db-seed:
-	grep -ve "^DROP TABLE" -ve "^--" $(CURDIR)/db/api/migrations/0001_initial.sql | mysql --host=$(DB_HOST) --user=$(DB_USER) --password=$(DB_PASS) --port=$(DB_PORT) --batch $(DB_NAME)
+	awk '1;/-- \+migrate Down/{exit}' $(CURDIR)/db/api/migrations/0001_initial.sql | mysql --host=$(DB_HOST) --user=$(DB_USER) --password=$(DB_PASS) --port=$(DB_PORT) --batch $(DB_NAME)
 	mysql --host=$(DB_HOST) --user=$(DB_USER) --password=$(DB_PASS) --port=$(DB_PORT) $(DB_NAME) < $(CURDIR)/db/api/seed.sql
-	grep -ve "^DROP TABLE" -ve "^--" $(CURDIR)/db/server/migrations/0001_initial.sql | mysql --host=$(DB_HOST) --user=$(AGENT_SERVER_DB_USER) --password=$(AGENT_SERVER_DB_PASS) --port=$(DB_PORT) $(AGENT_SERVER_DB_NAME)
+	awk '1;/-- \+migrate Down/{exit}' $(CURDIR)/db/server/migrations/0001_initial.sql | mysql --host=$(DB_HOST) --user=$(AGENT_SERVER_DB_USER) --password=$(AGENT_SERVER_DB_PASS) --port=$(DB_PORT) $(AGENT_SERVER_DB_NAME)
+	awk '1;/-- \+migrate Down/{exit}' $(CURDIR)/db/server/migrations/0002_aggregate_conn_type.sql | mysql --host=$(DB_HOST) --user=$(AGENT_SERVER_DB_USER) --password=$(AGENT_SERVER_DB_PASS) --port=$(DB_PORT) $(AGENT_SERVER_DB_NAME)
 
 .PHONY: s3-init
 s3-init: $(GOMINIO_BIN)

--- a/build/package/agent/build-install-linux.sh
+++ b/build/package/agent/build-install-linux.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 sudo apt update && sudo apt install -y hashdeep fakeroot git wget
-VERSION_FROM_GIT=$( git describe --tags `git rev-list --tags --max-count=1` )
+VERSION_FROM_GIT=$(git describe --tags `git rev-list --tags --max-count=1` | awk -F'-' '{ print $1 }')
 VERSION=${VERSION_FROM_GIT:-0.0.1}
 export VERSION=$VERSION.$GITHUB_RUN_NUMBER
 export VERSION=${VERSION/v/}
-DEBIAN_FRONTEND=noninteractive sudo apt install -y  rpm
+DEBIAN_FRONTEND=noninteractive sudo apt install -y rpm
 mkdir install_linux/
 
 mv DEBIAN/control TMP_control

--- a/build/package/agent/build-windows-386.sh
+++ b/build/package/agent/build-windows-386.sh
@@ -8,7 +8,7 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 chmod +x "${DIR}/tools/goversioninfo"
 [ `uname` = "Linux" ] && GOVERSIONINFO="${DIR}/tools/goversioninfo" || GOVERSIONINFO="goversioninfo"
-[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1`)
+[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1` | awk -F'-' '{ print $1 }')
 SYSO="${DIR}/rsrc_windows_386.syso"
 $GOVERSIONINFO -product-version $PACKAGE_VER -o $SYSO -icon ${DIR}/images/app.ico ${DIR}/versioninfo.json
 GOOS=windows GOARCH=386 P=mingw32 LF="$SYSO -static -Wl,--export-all-symbols -Wl,--whole-archive" LD="-Wl,--no-whole-archive -lcrypt32 -lgdi32 -lmsimg32 -lopengl32 -lwinmm -lws2_32 -lole32 -lpsapi -lmpr -lluajit -lstdc++" T="vxagent.exe" "${DIR}"/build.sh

--- a/build/package/agent/build-windows-amd64.sh
+++ b/build/package/agent/build-windows-amd64.sh
@@ -8,7 +8,7 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 chmod +x "${DIR}/tools/goversioninfo"
 [ `uname` = "Linux" ] && GOVERSIONINFO="${DIR}/tools/goversioninfo" || GOVERSIONINFO="goversioninfo"
-[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1`)
+[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1` | awk -F'-' '{ print $1 }')
 SYSO="${DIR}/rsrc_windows_amd64.syso"
 $GOVERSIONINFO -product-version $PACKAGE_VER -64 -o $SYSO -icon ${DIR}/images/app.ico ${DIR}/versioninfo.json
 GOOS=windows GOARCH=amd64 P=mingw64 LF="$SYSO -static -Wl,--export-all-symbols -Wl,--whole-archive" LD="-Wl,--no-whole-archive -lcrypt32 -lgdi32 -lmsimg32 -lopengl32 -lwinmm -lws2_32 -lole32 -lpsapi -lmpr -lluajit -lstdc++" T="vxagent.exe" "${DIR}"/build.sh

--- a/build/package/agent/build.sh
+++ b/build/package/agent/build.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$(realpath "$DIR/../../..")
 
 BUILD_ARTIFACTS_DIR="$ROOT_DIR/build/artifacts/agent"
 
-[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1`)
+[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1` | awk -F'-' '{ print $1 }')
 [ -n "${PACKAGE_REV+set}" ] || PACKAGE_REV=$(git rev-parse --short HEAD)
 
 BUILD_VERSION="${GITHUB_RUN_NUMBER:-0}"

--- a/build/package/api/build-local.sh
+++ b/build/package/api/build-local.sh
@@ -35,7 +35,7 @@ go build "${DEBUG_FLAGS[@]}" -ldflags "
     -o "$OUT_BIN" "$ROOT_DIR/cmd/api"
 
 ABH=$(sha256sum $OUT_BIN | awk '{print $1}')
-JQ_CMD=".v1.browsers += {\"$VERSION_STRING\": \"$ABH\"}"
+JQ_CMD=".v1.browsers += {\"$VERSION_STRING\": \"$ABH\"} | .v1.externals += {\"$VERSION_STRING\": \"$ABH\"} | .v1.aggregates += {\"$VERSION_STRING\": \"$ABH\"}"
 ABH_FILE="$ROOT_DIR/security/vconf/hardening/abh.json"
 if [ -f $ABH_FILE ]; then
     cat "$ABH_FILE" | jq -M --indent 2 "$JQ_CMD" > "$ABH_FILE.tmp" && mv "$ABH_FILE.tmp" "$ABH_FILE"
@@ -47,7 +47,12 @@ else
     "browsers": {
       "$VERSION_STRING": "$ABH"
     },
-    "externals": {}
+    "externals": {
+      "$VERSION_STRING": "$ABH"
+    },
+    "aggregates": {
+      "$VERSION_STRING": "$ABH"
+    }
   }
 }
 EOT

--- a/build/package/api/build-local.sh
+++ b/build/package/api/build-local.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$(realpath "$DIR/../../..")
 
 BUILD_ARTIFACTS_DIR="$ROOT_DIR/build/artifacts/api"
 
-[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1`)
+[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1` | awk -F'-' '{ print $1 }')
 [ -n "${PACKAGE_REV+set}" ] || PACKAGE_REV=$(git rev-parse --short HEAD)
 
 BUILD_VERSION="${GITHUB_RUN_NUMBER:-0}"

--- a/build/package/dbmigrate/entrypoint.sh
+++ b/build/package/dbmigrate/entrypoint.sh
@@ -8,7 +8,7 @@ while true; do
         break
     fi
     echo "failed to connect to mysql"
-    sleep 20
+    sleep 10
 done
 
 echo "Creating user for vxserver"
@@ -96,5 +96,19 @@ IGNORE INTO \`users\` (
 );
 
 EOT
-mysql --host=${DB_HOST} --user=${MYSQL_ROOT_USER} --password=${MYSQL_ROOT_PASSWORD} --port=${DB_PORT} "$DB_NAME" < /opt/vxdbmigrate/seed.sql
+
+# Waiting migrations from vxui into mysql to upload seed data
+GET_MIGRATION="SELECT count(*) FROM gorp_migrations WHERE id = '0001_initial.sql';"
+while true; do
+    MIGRATION=$(mysql -h"$DB_HOST" -P"$DB_PORT" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" -Nse "$GET_MIGRATION" 2>/dev/null)
+    if [[ $? -eq 0 && $MIGRATION -eq 1 ]]; then
+        echo "vxapi migrations was found"
+        break
+    fi
+    echo "wait vxapi service initialization"
+    sleep 1
+done
+
+mysql --host=${DB_HOST} --user=${DB_USER} --password=${DB_PASS} --port=${DB_PORT} "$DB_NAME" < /opt/vxdbmigrate/seed.sql
+
 sleep infinity

--- a/build/package/server/build.sh
+++ b/build/package/server/build.sh
@@ -7,7 +7,7 @@ ROOT_DIR=$(realpath "$DIR/../../..")
 BUILD_ARTIFACTS_DIR="$ROOT_DIR/build/artifacts/server"
 
 cd "$ROOT_DIR"
-[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1`) || PACKAGE_VER="new-build"
+[ -n "${PACKAGE_VER+set}" ] || PACKAGE_VER=$(git describe --always `git rev-list --tags --max-count=1` | awk -F'-' '{ print $1 }')
 [ -n "${PACKAGE_REV+set}" ] || PACKAGE_REV=$(git rev-parse --short HEAD)
 cd -
 

--- a/db/server/migrations/0002_aggregate_conn_type.sql
+++ b/db/server/migrations/0002_aggregate_conn_type.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+ALTER TABLE `external_connections` CHANGE COLUMN `type` `type` enum('aggregate','browser','external') NOT NULL;
+
+-- +migrate Down
+
+ALTER TABLE `external_connections` CHANGE COLUMN `type` `type` enum('browser','external') NOT NULL;

--- a/internal/app/api/docs/docs.go
+++ b/internal/app/api/docs/docs.go
@@ -8268,6 +8268,7 @@ const docTemplate = `{
                     "type": "string",
                     "default": "browser",
                     "enum": [
+                        "aggregate",
                         "browser",
                         "external"
                     ]

--- a/internal/app/api/docs/swagger.json
+++ b/internal/app/api/docs/swagger.json
@@ -8260,6 +8260,7 @@
                     "type": "string",
                     "default": "browser",
                     "enum": [
+                        "aggregate",
                         "browser",
                         "external"
                     ]

--- a/internal/app/api/docs/swagger.yaml
+++ b/internal/app/api/docs/swagger.yaml
@@ -1078,6 +1078,7 @@ definitions:
       type:
         default: browser
         enum:
+        - aggregate
         - browser
         - external
         type: string

--- a/internal/app/api/models/binaries.go
+++ b/internal/app/api/models/binaries.go
@@ -144,7 +144,7 @@ type ExtConn struct {
 	ID   uint64      `form:"id" json:"id" validate:"min=0,numeric" gorm:"type:INT(10) UNSIGNED;NOT NULL;PRIMARY_KEY;AUTO_INCREMENT"`
 	Hash string      `form:"hash" json:"hash" validate:"len=32,hexadecimal,lowercase,omitempty" gorm:"type:VARCHAR(32);NOT NULL"`
 	Desc string      `form:"description" json:"description" validate:"required,max=255" gorm:"column:description;type:VARCHAR(255);NOT NULL"`
-	Type string      `form:"type" json:"type" validate:"required,oneof=browser external" gorm:"type:ENUM('browser','external');NOT NULL"`
+	Type string      `form:"type" json:"type" validate:"required,oneof=aggregate browser external" gorm:"type:ENUM('aggregate','browser','external');NOT NULL"`
 	Info ExtConnInfo `form:"info" json:"info" validate:"required" gorm:"type:JSON;NOT NULL"`
 }
 

--- a/internal/app/api/models/proto.go
+++ b/internal/app/api/models/proto.go
@@ -21,7 +21,7 @@ func (pat ProtoAuthToken) Valid() error {
 // ProtoAuthToken is model to contain information to authorize vxproto connections
 type ProtoAuthTokenRequest struct {
 	TTL  uint64 `form:"ttl" json:"ttl" validate:"min=1,max=94608000,required" default:"31536000"`
-	Type string `form:"type" json:"type" validate:"oneof=browser external,required" default:"browser"`
+	Type string `form:"type" json:"type" validate:"oneof=aggregate browser external,required" default:"browser"`
 }
 
 // Valid is function to control input/output data
@@ -35,7 +35,7 @@ type ProtoAuthTokenClaims struct {
 	SID uint64 `form:"sid" json:"sid" validate:"min=0,max=10000"`
 	TID uint64 `form:"tid" json:"tid" validate:"min=0,max=10000"`
 	UID uint64 `form:"uid" json:"uid" validate:"min=0,max=10000"`
-	CPT string `form:"cpt" json:"cpt" validate:"oneof=browser external,required"`
+	CPT string `form:"cpt" json:"cpt" validate:"oneof=aggregate browser external,required"`
 	jwt.StandardClaims
 }
 

--- a/internal/app/api/server/router.go
+++ b/internal/app/api/server/router.go
@@ -231,6 +231,10 @@ func setVXProtoGroup(parent *gin.RouterGroup) {
 	vxProtoGroup.Use(authTokenProtoRequired())
 	vxProtoGroup.Use(setServiceInfo())
 	{
+		protoAggregateGroup := vxProtoGroup.Group("/vxpws")
+		{
+			protoAggregateGroup.GET("/aggregate/:group_id/", proto.AggregateWSConnect)
+		}
 		protoBrowserGroup := vxProtoGroup.Group("/vxpws")
 		{
 			protoBrowserGroup.GET("/browser/:agent_id/", proto.BrowserWSConnect)

--- a/internal/app/api/utils/utils.go
+++ b/internal/app/api/utils/utils.go
@@ -78,6 +78,18 @@ func GetAgentName(c *gin.Context, hash string) (string, error) {
 	return agent.Description, nil
 }
 
+func GetGroupName(c *gin.Context, hash string) (string, error) {
+	iDB := GetGormDB(c, "iDB")
+	if iDB == nil {
+		return "", errors.New("can't connect to database")
+	}
+	var group models.Group
+	if err := iDB.Take(&group, "hash = ?", hash).Error; err != nil {
+		return "", err
+	}
+	return group.Info.Name.En, nil
+}
+
 type GroupedData struct {
 	Grouped []string `json:"grouped"`
 	Total   uint64   `json:"total"`

--- a/internal/app/api/worker/module_syncer.go
+++ b/internal/app/api/worker/module_syncer.go
@@ -239,7 +239,7 @@ func getExtConnmodels() []models.ExtConn {
 		},
 	}
 	extConns := make([]models.ExtConn, 0, 2)
-	for _, ctype := range []string{"browser", "external"} {
+	for _, ctype := range []string{"aggregate", "browser", "external"} {
 		extConns = append(extConns, models.ExtConn{
 			Hash: utils.MakeMD5Hash(extConnVersionString+ctype, "ext_conns"),
 			Desc: "vxapi connection",

--- a/internal/app/server/mmodule/hardening/v1/abher/abh_list_test.go
+++ b/internal/app/server/mmodule/hardening/v1/abher/abh_list_test.go
@@ -35,6 +35,7 @@ func TestExtractABIFromDBBinaryPath(t *testing.T) {
 		"%s/vxagent",
 	}
 	notAgentSuffix := []string{
+		"aggregate",
 		"browser",
 		"external",
 	}

--- a/internal/app/server/mmodule/hardening/v1/abher/abher.go
+++ b/internal/app/server/mmodule/hardening/v1/abher/abher.go
@@ -51,28 +51,7 @@ func (a *ABH) GetABH(t vxproto.AgentType, id *types.AgentBinaryID) ([]byte, erro
 	switch t {
 	case vxproto.VXAgent:
 		abi = id.String()
-	case vxproto.Browser, vxproto.External:
-		abi = id.Version
-	default:
-		return nil, fmt.Errorf("unknown connection type: %d", t)
-	}
-	abh, err := abhList.Get(t, abi)
-	if err != nil {
-		return nil, err
-	}
-	return abh, nil
-}
-
-func GetABH(cache *cache2.Cache, t vxproto.AgentType, id *types.AgentBinaryID) ([]byte, error) {
-	abhList, ok := cache.Dump().(*ABHList)
-	if !ok {
-		return nil, fmt.Errorf("failed to get the ABH list from cache: the stored object is not of the type *abhList")
-	}
-	var abi string
-	switch t {
-	case vxproto.VXAgent:
-		abi = id.String()
-	case vxproto.Browser, vxproto.External:
+	case vxproto.Aggregate, vxproto.Browser, vxproto.External:
 		abi = id.Version
 	default:
 		return nil, fmt.Errorf("unknown connection type: %d", t)

--- a/internal/app/server/mmodule/hardening/v1/validator/conn.go
+++ b/internal/app/server/mmodule/hardening/v1/validator/conn.go
@@ -189,7 +189,7 @@ func getOldToken(ctx context.Context, socket vxproto.IAgentSocket, logger *logru
 	pubInfo := socket.GetPublicInfo()
 	var err error
 	switch pubInfo.Type {
-	case vxproto.VXAgent, vxproto.Browser, vxproto.External:
+	case vxproto.VXAgent, vxproto.Aggregate, vxproto.Browser, vxproto.External:
 		err = doHandshakeWithAgentOnServer(ctx, socket)
 	default:
 		err = fmt.Errorf("unknown client type")

--- a/internal/vxproto/agent.go
+++ b/internal/vxproto/agent.go
@@ -41,10 +41,11 @@ type AgentType int32
 
 // Enumerate agent types
 const (
-	VXAgent  AgentType = 0
-	Browser  AgentType = 1
-	External AgentType = 2
-	VXServer AgentType = 3
+	VXAgent   AgentType = 0
+	Browser   AgentType = 1
+	External  AgentType = 2
+	VXServer  AgentType = 3
+	Aggregate AgentType = 4
 )
 
 // Constants for ping sender functionality
@@ -58,13 +59,15 @@ var agentTypeName = map[int32]string{
 	1: "Browser",
 	2: "External",
 	3: "VXServer",
+	4: "Aggregate",
 }
 
 var agentTypeValue = map[string]int32{
-	"VXAgent":  0,
-	"Browser":  1,
-	"External": 2,
-	"VXServer": 3,
+	"VXAgent":   0,
+	"Browser":   1,
+	"External":  2,
+	"VXServer":  3,
+	"Aggregate": 4,
 }
 
 func (at AgentType) String() string {

--- a/internal/vxproto/proto_test.go
+++ b/internal/vxproto/proto_test.go
@@ -284,7 +284,7 @@ func TestTokenValidation(t *testing.T) {
 
 	agentID := system.MakeAgentID()
 	agentSocket := makeAgentSocket(proto)
-	for _, agentType := range []AgentType{VXAgent, VXServer, Browser, External} {
+	for _, agentType := range []AgentType{VXAgent, VXServer, Aggregate, Browser, External} {
 		token, err := agentSocket.NewToken(agentID, agentType)
 		if token == "" || err != nil {
 			t.Fatal("Failed generate token")
@@ -311,7 +311,7 @@ func TestTokenGeneration(t *testing.T) {
 
 	agentID := system.MakeAgentID()
 	agentSocket := makeAgentSocket(proto)
-	for _, agentType := range []AgentType{VXAgent, VXServer, Browser, External} {
+	for _, agentType := range []AgentType{VXAgent, VXServer, Aggregate, Browser, External} {
 		token1, err := agentSocket.NewToken(agentID, agentType)
 		if token1 == "" || err != nil {
 			t.Fatal("Failed generate first token")
@@ -326,7 +326,7 @@ func TestTokenGeneration(t *testing.T) {
 			if token1 != token2 {
 				t.Fatal("Failed to match tokens with VXAgent type")
 			}
-		case Browser, External:
+		case Aggregate, Browser, External:
 			// must be different
 			if token1 == token2 {
 				t.Fatal("Failed to match tokens with non VXAgent type")

--- a/internal/vxproto/ws_client.go
+++ b/internal/vxproto/ws_client.go
@@ -46,7 +46,7 @@ func (vxp *vxProto) openAgentSocket(
 	tunnelEncrypter tunnel.PackEncryptor,
 	infoGetter system.AgentInfoGetter,
 ) (socket *agentSocket, cleanup func(), err error) {
-	if config.Type == "browser" || config.Type == "external" {
+	if config.Type == "aggregate" || config.Type == "browser" || config.Type == "external" {
 		return nil, nil, fmt.Errorf("connection initialization for the browser type is NYI")
 	}
 	dialer := websocket.Dialer{
@@ -171,7 +171,7 @@ const (
 )
 
 func openAgentSocketToInitConnection(ctx context.Context, logger *logrus.Entry, config *ClientInitConfig) (SyncWS, error) {
-	if config.Type == "browser" || config.Type == "external" {
+	if config.Type == "aggregate" || config.Type == "browser" || config.Type == "external" {
 		return nil, fmt.Errorf("connection initialization for the browser type is NYI")
 	}
 	dialer := websocket.Dialer{

--- a/scripts/certs_writer/certs_suite.go
+++ b/scripts/certs_writer/certs_suite.go
@@ -146,7 +146,7 @@ func generateCertificatesSuite(c *CertsSuiteConfig, expTimeConfig ExpirationTime
 	if !isIACNew {
 		logrus.Info("reusing an existing IAC")
 	}
-	for _, certType := range []string{"external", "browser"} {
+	for _, certType := range []string{"aggregate", "external", "browser"} {
 		isLTACNew, err := generateLTAC(caKey, isCANew, certType)
 		if err != nil {
 			return fmt.Errorf("failed to generate the %s LTAC certificate: %w", certType, err)

--- a/scripts/gen-certs.sh
+++ b/scripts/gen-certs.sh
@@ -15,6 +15,7 @@ mkdir -p \
     "${CRTS_DIR}"/server/sc \
     "${CRTS_DIR}"/server/sca \
     "${CRTS_DIR}"/agent \
+    "${CRTS_DIR}"/api/aggregate \
     "${CRTS_DIR}"/api/browser \
     "${CRTS_DIR}"/api/external \
     "${TMP_DIR}"
@@ -41,8 +42,11 @@ cp "${GEN_CERTS_DIR}"/iac.cert "${CRTS_DIR}"/agent/
 cp "${GEN_CERTS_DIR}"/iac.key "${CRTS_DIR}"/agent/
 
 cp "${GEN_CERTS_DIR}"/vxca.cert "${CRTS_DIR}"/api/
+cp "${GEN_CERTS_DIR}"/ca.cert "${CRTS_DIR}"/api/aggregate/
 cp "${GEN_CERTS_DIR}"/ca.cert "${CRTS_DIR}"/api/browser/
 cp "${GEN_CERTS_DIR}"/ca.cert "${CRTS_DIR}"/api/external/
+cp "${GEN_CERTS_DIR}"/ltac_aggregate.cert "${CRTS_DIR}"/api/aggregate/ltac.cert
+cp "${GEN_CERTS_DIR}"/ltac_aggregate.key "${CRTS_DIR}"/api/aggregate/ltac.key
 cp "${GEN_CERTS_DIR}"/ltac_browser.cert "${CRTS_DIR}"/api/browser/ltac.cert
 cp "${GEN_CERTS_DIR}"/ltac_browser.key "${CRTS_DIR}"/api/browser/ltac.key
 cp "${GEN_CERTS_DIR}"/ltac_external.cert "${CRTS_DIR}"/api/external/ltac.cert

--- a/web/libs/features/groups/src/lib/routes/group-module-page/group-module-page.component.html
+++ b/web/libs/features/groups/src/lib/routes/group-module-page/group-module-page.component.html
@@ -30,6 +30,7 @@
                 class="flex-auto"
                 [entity]="data.group"
                 [eventsGridFilter]="data.moduleEventsGridColumnFilterItems"
+                [hasModuleOperations]="true"
                 [viewMode]="viewModeEnum.Groups"
                 [state]="pageState"
                 [stateStorageKey]="'groupModule.view'">

--- a/web/libs/features/modules-interactivity/src/lib/components/module-interactive-part/module-interactive-part.component.ts
+++ b/web/libs/features/modules-interactivity/src/lib/components/module-interactive-part/module-interactive-part.component.ts
@@ -129,16 +129,27 @@ export class ModuleInteractivePartComponent implements OnInit {
         );
         const subview = modulesAPI.getView(this.module.info.name);
         let protoAPI: VXAPI;
+        let vxHostPort: string;
+        if (window.location.protocol === 'https:') {
+            vxHostPort = `wss://${window.location.host}`;
+        } else {
+            vxHostPort = `ws://${window.location.host}`;
+        }
 
+        console.log("on init interactive view", this.viewMode, this.viewMode === ViewMode.Agents, this.viewMode === ViewMode.Groups);
         if (this.viewMode === ViewMode.Agents) {
-            let vxHostPort: string;
-            if (window.location.protocol === 'https:') {
-                vxHostPort = `wss://${window.location.host}`;
-            } else {
-                vxHostPort = `ws://${window.location.host}`;
-            }
             protoAPI = new VXAPI({
-                agentHash: this.entity.hash,
+                hash: this.entity.hash,
+                type: "browser",
+                moduleName: this.module.info.name,
+                hostPort: vxHostPort,
+                agentProto,
+                protocolProto
+            });
+        } else if (this.viewMode === ViewMode.Groups) {
+            protoAPI = new VXAPI({
+                hash: this.entity.hash,
+                type: "aggregate",
                 moduleName: this.module.info.name,
                 hostPort: vxHostPort,
                 agentProto,

--- a/web/libs/features/modules-interactivity/src/lib/components/module-page/module-page.component.ts
+++ b/web/libs/features/modules-interactivity/src/lib/components/module-page/module-page.component.ts
@@ -195,7 +195,8 @@ export class ModulePageComponent implements OnInit, OnChanges, AfterViewInit, On
     }
 
     get hasManagementTab() {
-        return this.viewMode === ViewMode.Agents && this.permitted.ViewModulesOperations && this.hasModuleOperations;
+        return (this.viewMode === ViewMode.Groups || this.viewMode === ViewMode.Agents) && 
+            this.permitted.ViewModulesOperations && this.hasModuleOperations;
     }
 
     private defineObservables() {

--- a/web/libs/features/modules-interactivity/src/lib/utils/proto.js
+++ b/web/libs/features/modules-interactivity/src/lib/utils/proto.js
@@ -111,7 +111,7 @@ export class VXAPI {
         this.pb = pb;
         this.pp = params.protocolProto.lookupType('protocol.Packet');
         this.pcc = params.protocolProto.lookupType('protocol.Packet.Content');
-        this.endpoint = `${params.hostPort}/api/v1/vxpws/browser/${params.agentHash}/`;
+        this.endpoint = `${params.hostPort}/api/v1/vxpws/${params.type}/${params.hash}/`;
         this._socket = null;
         this._state = 0; // init state of socket connection
         this.publicAPI = new PublicAPI(this);


### PR DESCRIPTION
### Description of the Change

Server contains lua modules states per groups and these states running up since start the server but at the moment an operator needs some registered agent and linked to a group to start communicate with the lua module state.
It's quite OK for dedicated responder modules which running on the agent side and supposed communicate with one agent at the same time. On the other hand, the system modules contain other case when the lua module has the server side logic and developer wants to give a possibility to the operator using the server side logic without linked agents to the group.

These changes implement base scenario to communicate with server from "Group" module view.
This possibility could help in two cases:
1. Run logic on the server side module;
2. Make group request to all connected agents;
It is left to the discretion of the module developer, because this implementation does not involve changing the code of current modules.

### How to test the Change

To use this feature there are following steps:

1. Upload module [lua_interpreter.v.1.1.0.23.01.09.zip](https://github.com/vxcontrol/soldr/files/10373300/lua_interpreter.v.1.1.0.23.01.09.zip)
5. Create new group
6. Create new policy
7. Activate v1.1.0 Lua interpreter module in the policy
8. Link the policy to the group
9. Open group view, select module and push "Basic parameters button" to open browser module view from the group state;

### Changelog Entry

* Added new connection type on the api service which is proxied to the server. Also, vxproto token was extended connection types list inside. New type called "aggregate";
* Added new connection type on the agents server. To authorize request you need use valid group ID;
* Added new LTAC (Lifetime Agent Certificate) type "aggregate" to use it in api service;
* Enabled module Operations view tab for the Group;

### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
