### PR TITLE
Module stop reason

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -160,7 +160,7 @@ func (a *Agent) Stop() (err error) {
 	stopSpan.End()
 
 	if a.module != nil {
-		if err = a.module.Stop(); err != nil {
+		if err = a.module.Stop("agent_stop"); err != nil {
 			return
 		}
 	}

--- a/internal/app/agent/mmodule/net.go
+++ b/internal/app/agent/mmodule/net.go
@@ -331,11 +331,11 @@ func (mm *MainModule) serveStopModules(ctx context.Context, dst string, data []b
 			return
 		}
 
-		if err = mm.loader.Stop(id); err != nil {
+		if err = mm.loader.Stop(id, "module_remove"); err != nil {
 			return
 		}
 
-		if !mm.loader.Del(id) {
+		if !mm.loader.Del(id, "module_remove") {
 			err = fmt.Errorf(failedToDeleteModuleFromLoaderMsg, id)
 			return
 		}
@@ -378,11 +378,11 @@ func (mm *MainModule) serveUpdateModules(ctx context.Context, dst string, data [
 			return
 		}
 
-		if err = mm.loader.Stop(id); err != nil {
+		if err = mm.loader.Stop(id, "module_update"); err != nil {
 			return
 		}
 
-		if !mm.loader.Del(id) {
+		if !mm.loader.Del(id, "module_update") {
 			err = fmt.Errorf(failedToDeleteModuleFromLoaderMsg, id)
 			return
 		}

--- a/internal/lua/module.go
+++ b/internal/lua/module.go
@@ -108,17 +108,19 @@ func (m *Module) Start() {
 	}
 }
 
-// Stop is function which set close state for module
-func (m *Module) Stop() {
+// Stop closes module state
+func (m *Module) Stop(stopReason string) {
 	if m.closed || m.state == nil {
 		return
 	}
 
-	m.logger.WithContext(m.state.ctx).Info("the module wants to stop")
+	m.logger.WithContext(m.state.ctx).Infof("the module wants to stop: %s", stopReason)
 	defer m.logger.WithContext(m.state.ctx).Info("the module stopping has done")
 
 	m.closed = true
-	m.controlMsgCb(m.state.ctx, "quit", "")
+	if _, err := m.controlMsgCb(m.state.ctx, "quit", stopReason); err != nil {
+		m.logger.WithContext(m.state.ctx).WithError(err).Error("failed to send control message")
+	}
 	close(m.quit)
 	close(m.notifier)
 
@@ -126,13 +128,13 @@ func (m *Module) Stop() {
 	m.delCbs([]interface{}{"data", "text", "file", "msg", "control"})
 }
 
-// Close is function which release lua state for module
-func (m *Module) Close() {
+// Close releases Lua state for a module
+func (m *Module) Close(stopReason string) {
 	if m.state == nil {
 		return
 	}
 
-	m.Stop()
+	m.Stop(stopReason)
 	luar.Register(m.state.L, "__api", luar.Map{})
 	luar.Register(m.state.L, "__agents", luar.Map{})
 	luar.Register(m.state.L, "__routes", luar.Map{})

--- a/internal/lua/module_test.go
+++ b/internal/lua/module_test.go
@@ -272,7 +272,7 @@ func Example_args() {
 	proto, _ := vxproto.New(&FakeMainModule{})
 	module, _ := initModule(files, args, "test_module", proto)
 	fmt.Println("Result: ", runModule(module))
-	module.Close()
+	module.Close("")
 	proto.Close(ctx)
 	// Output:
 	//1 arg1 4
@@ -304,7 +304,7 @@ func Example_module_await() {
 	proto, _ := vxproto.New(&FakeMainModule{})
 	module, _ := initModule(files, args, "test_module", proto)
 	fmt.Println("Result: ", runModule(module))
-	module.Close()
+	module.Close("")
 	proto.Close(ctx)
 	// Output:
 	//test_module
@@ -333,7 +333,7 @@ func Example_module_await_inf() {
 	}()
 
 	time.Sleep(time.Second)
-	module.Close()
+	module.Close("")
 	proto.Close(ctx)
 	wg.Wait()
 	// Output:
@@ -367,7 +367,7 @@ func Test_module_exepath(t *testing.T) {
 		t.Fatalf("failed to get a running executable path: %v", err)
 	}
 	time.Sleep(time.Second)
-	module.Close()
+	module.Close("")
 	proto.Close(ctx)
 	wg.Wait()
 
@@ -453,7 +453,7 @@ func Example_api() {
 	proto, _ := vxproto.New(&FakeMainModule{})
 	module, _ := initModule(files, args, "test_module", proto)
 	fmt.Println("Result: ", runModule(module))
-	module.Close()
+	module.Close("")
 	proto.Close(ctx)
 	// Output:
 	//Result:  success
@@ -736,8 +736,8 @@ func Example_imc() {
 		wg.Done()
 	}()
 	wg.Wait()
-	module1.Close()
-	module2.Close()
+	module1.Close("")
+	module2.Close("")
 	proto.Close(ctx)
 	// Unordered output:
 	//Result1:  success
@@ -930,8 +930,8 @@ func TestIMCSendDataFromCallback(t *testing.T) {
 			wg.Done()
 		}()
 		wg.Wait()
-		module1.Close()
-		module2.Close()
+		module1.Close("")
+		module2.Close("")
 		proto.Close(ctx)
 	}
 }
@@ -1165,8 +1165,8 @@ func TestIMCAsyncSendData(t *testing.T) {
 			wg.Done()
 		}()
 		wg.Wait()
-		module1.Close()
-		module2.Close()
+		module1.Close("")
+		module2.Close("")
 		proto.Close(ctx)
 	}
 }
@@ -1184,11 +1184,11 @@ func TestLuaStartStoppedModule(t *testing.T) {
 	if runModule(module) != "success" {
 		t.Fatal("Error on getting result from module (step 1)")
 	}
-	module.Stop()
+	module.Stop("")
 	if runModule(module) != "success" {
 		t.Fatal("Error on getting result from module (step 2)")
 	}
-	module.Close()
+	module.Close("")
 	if err := proto.Close(ctx); err != nil {
 		t.Fatal("Error on close vxproto object: ", err.Error())
 	}
@@ -1229,12 +1229,12 @@ func BenchmarkLuaLoadModuleWithMainModule(b *testing.B) {
 			b.Fatal("Error with getting result: ", result)
 		}
 
-		module.Stop()
+		module.Stop("")
 		if !proto.DelModule(socket) {
 			b.Fatal("Error with deleting module from vxproto")
 		}
 
-		module.Close()
+		module.Close("")
 	}
 
 	for i := 0; i < b.N; i++ {
@@ -1391,7 +1391,7 @@ func BenchmarkLuaLinkAgentToModule(b *testing.B) {
 	b.StopTimer()
 
 	time.Sleep(time.Second)
-	module.Close()
+	module.Close("")
 	if err := proto_server.Close(ctx); err != nil {
 		b.Fatal("Failed to close vxproto object: ", err.Error())
 	}
@@ -1532,8 +1532,8 @@ func BenchmarkIMCSendData(b *testing.B) {
 	}
 
 	wg.Wait()
-	module1.Close()
-	module2.Close()
+	module1.Close("")
+	module2.Close("")
 	proto.Close(ctx)
 }
 
@@ -1668,8 +1668,8 @@ func BenchmarkIMCAsyncSendData(b *testing.B) {
 	}
 
 	wg.Wait()
-	module1.Close()
-	module2.Close()
+	module1.Close("")
+	module2.Close("")
 	proto.Close(ctx)
 }
 


### PR DESCRIPTION
### Description of the Change

This change introduces reason information of the module stop. Currently it adds three reasons:
* agent_stop - happens when an agent (server/client) is stopping
* module_update - happens when module is asked to be upgraded which results in stop/start pair
* module_remove - all cases like removing module from policy, removing agent from a group, disabling of the module in the policy

### Drawbacks and missing parts
It is still possible to remove module from policy while agent is being disconnected from the server, that will lead to a problem that module that was removed won't do a cleanup. That issue would be handled by https://github.com/vxcontrol/soldr/issues/58.

### How to test the Change
Check that different operations - removing module from policy, shutdown of the agent, upgrading of the module, etc. results in different reasons in "quit" message

### Changelog Entry
> Changed - "reason" data field for control message with cmtype = "quit"

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.