### PR TITLE
fix lua modules tests: issue due to merge typo

### DIFF
--- a/internal/lua/module_test.go
+++ b/internal/lua/module_test.go
@@ -527,7 +527,7 @@ func Example_topics_api() {
 	proto, _ := vxproto.New(&FakeMainModule{})
 	module, _ := initModule(files, args, "test_module", proto)
 	fmt.Println("Result: ", runModule(module))
-	module.Close()
+	module.Close("")
 	proto.Close(ctx)
 	// Output:
 	//Received: test_data
@@ -1223,9 +1223,9 @@ func TestIMCSendDataToTopic(t *testing.T) {
 			wg.Done()
 		}()
 		wg.Wait()
-		module1.Close()
+		module1.Close("")
 		for _, module := range module2 {
-			module.Close()
+			module.Close("")
 		}
 		proto.Close(ctx)
 	}


### PR DESCRIPTION
The PR just fixes issue in tests introduced by previous merge: adds some missing params in the tests.

### How to test the Change
* Check CI

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
