### PR TITLE
reset password_change_required on user patch

### DIFF
--- a/pkg/app/api/server/private/users.go
+++ b/pkg/app/api/server/private/users.go
@@ -455,14 +455,16 @@ func (s *UserService) PatchUser(c *gin.Context) {
 
 	public_info := []interface{}{"mail", "name", "status"}
 	if user.Password != "" {
-		if encPassword, err := utils.EncryptPassword(user.Password); err != nil {
+		var encPassword []byte
+		encPassword, err = utils.EncryptPassword(user.Password)
+		if err != nil {
 			utils.FromContext(c).WithError(err).Errorf("error encoding password")
 			response.Error(c, response.ErrInternal, err)
 			return
-		} else {
-			user.Password = string(encPassword)
-			public_info = append(public_info, "password")
 		}
+		user.Password = string(encPassword)
+		user.PasswordChangeRequired = false
+		public_info = append(public_info, "password", "password_change_required")
 		err = s.db.Scopes(scope).Select("", public_info...).Save(&user).Error
 	} else {
 		err = s.db.Scopes(scope).Select("", public_info...).Save(&user.User).Error


### PR DESCRIPTION
Fix inconsistent logic: password change request already updates password_change_required field however update of the use missed that logic.

### Description of the Change
Reset password_change_required value if user password is changed due to PUT /api/v1/users/{hash} call.

### How to test the Change
* install Soldr from scratch / update password_change_required in the DB for one of the users
* try to update user password using PUT /api/v1/users/{hash} call

### Changelog Entry
> Changed - PUT /api/v1/users/{hash} resets password_change_required user property.

### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
