### PR TITLE
Refactor auth middlewares

### DIFF
--- a/pkg/app/api/server/auth_middleware.go
+++ b/pkg/app/api/server/auth_middleware.go
@@ -61,7 +61,6 @@ func (p *AuthMiddleware) tryAuth(c *gin.Context, authMethods ...func(c *gin.Cont
 
 	if result != authResultOk {
 		response.Error(c, response.ErrAuthRequired, nil)
-		c.Abort()
 		return
 	}
 	c.Next()

--- a/pkg/app/api/server/auth_middleware.go
+++ b/pkg/app/api/server/auth_middleware.go
@@ -136,16 +136,16 @@ func (p *AuthMiddleware) tryProtoCookieAuthentication(c *gin.Context) authResult
 
 	for _, attr := range []interface{}{uid, rid, sid, tid, prm, exp, gtm, uname} {
 		if attr == nil {
-			return authResultFail // response.Error(c, response.ErrNotPermitted, errors.New(msg))
+			return authResultFail
 		}
 	}
 
 	prms, ok := prm.([]string)
 	if !ok {
-		return authResultFail // response.Error(c, response.ErrNotPermitted, nil)
+		return authResultFail
 	}
 	if !lookupPerm(prms, privilegeInteractive) {
-		return authResultFail // response.Error(c, response.ErrNotPermitted, nil)
+		return authResultFail
 	}
 	c.Set("prm", prms)
 
@@ -171,11 +171,11 @@ func (p *AuthMiddleware) tryProtoCookieAuthentication(c *gin.Context) authResult
 func (p *AuthMiddleware) tryProtoTokenAuthentication(c *gin.Context) authResult {
 	authHeader := c.Request.Header.Get("Authorization")
 	if authHeader == "" {
-		return authResultSkip // "token required"
+		return authResultSkip
 	}
 
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return authResultSkip // "must be used bearer schema"
+		return authResultSkip
 	}
 	token := authHeader[7:]
 	if token == "" {
@@ -184,7 +184,7 @@ func (p *AuthMiddleware) tryProtoTokenAuthentication(c *gin.Context) authResult 
 
 	claims, err := private.ValidateToken(token)
 	if err != nil {
-		return authResultFail // "token invalid"
+		return authResultFail
 	}
 
 	c.Set("uid", claims.UID)

--- a/pkg/app/api/server/auth_middleware.go
+++ b/pkg/app/api/server/auth_middleware.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"soldr/pkg/app/api/server/private"
+	"soldr/pkg/app/api/server/response"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+)
+
+type authResult int
+
+const (
+	authResultOk authResult = iota
+	authResultSkip
+	authResultFail
+	authResultAbort
+)
+
+type AuthMiddleware struct {
+	connectionTypeRegexp *regexp.Regexp
+}
+
+func NewAuthMiddleware(baseURL string) *AuthMiddleware {
+	return &AuthMiddleware{
+		connectionTypeRegexp: regexp.MustCompile(
+			fmt.Sprintf("%s/vxpws/(aggregate|browser|external)/.*", baseURL),
+		),
+	}
+}
+
+func (p *AuthMiddleware) AuthRequired(c *gin.Context) {
+	p.tryAuth(c,
+		p.tryUserCookieAuthentication,
+	)
+}
+
+func (p *AuthMiddleware) AuthTokenProtoRequired(c *gin.Context) {
+	p.tryAuth(c,
+		p.tryProtoTokenAuthentication,
+		p.tryProtoCookieAuthentication,
+	)
+}
+
+func (p *AuthMiddleware) tryAuth(c *gin.Context, authMethods ...func(c *gin.Context) authResult) {
+	if c.IsAborted() {
+		return
+	}
+
+	result := authResultSkip
+	for _, authMethod := range authMethods {
+		result = authMethod(c)
+		if result != authResultSkip {
+			break
+		}
+	}
+
+	if result != authResultOk {
+		response.Error(c, response.ErrAuthRequired, nil)
+		c.Abort()
+		return
+	}
+	c.Next()
+}
+
+func (p *AuthMiddleware) tryUserCookieAuthentication(c *gin.Context) authResult {
+	sessionObject, exists := c.Get(sessions.DefaultKey)
+	if !exists {
+		return authResultSkip
+	}
+
+	session, ok := sessionObject.(sessions.Session)
+	if !ok {
+		return authResultFail
+	}
+
+	uid := session.Get("uid")
+	rid := session.Get("rid")
+	sid := session.Get("sid")
+	tid := session.Get("tid")
+	prm := session.Get("prm")
+	exp := session.Get("exp")
+	gtm := session.Get("gtm")
+	uname := session.Get("uname")
+	svc := session.Get("svc")
+
+	for _, attr := range []interface{}{uid, rid, sid, tid, prm, exp, gtm, uname, svc} {
+		if attr == nil {
+			return authResultFail
+		}
+	}
+
+	prms, ok := prm.([]string)
+	if !ok {
+		return authResultFail
+	}
+
+	c.Set("prm", prms)
+	c.Set("uid", uid.(uint64))
+	c.Set("rid", rid.(uint64))
+	c.Set("sid", sid.(uint64))
+	c.Set("tid", tid.(uint64))
+	c.Set("exp", exp.(int64))
+	c.Set("gtm", gtm.(int64))
+	c.Set("uname", uname.(string))
+	c.Set("svc", svc.(string))
+
+	return authResultOk
+}
+
+const privilegeInteractive = "vxapi.modules.interactive"
+
+func (p *AuthMiddleware) tryProtoCookieAuthentication(c *gin.Context) authResult {
+	sessionObject, exists := c.Get(sessions.DefaultKey)
+	if !exists {
+		return authResultSkip
+	}
+
+	session, ok := sessionObject.(sessions.Session)
+	if !ok {
+		return authResultFail
+	}
+
+	uid := session.Get("uid")
+	rid := session.Get("rid")
+	sid := session.Get("sid")
+	tid := session.Get("tid")
+	prm := session.Get("prm")
+	exp := session.Get("exp")
+	gtm := session.Get("gtm")
+	uname := session.Get("uname")
+
+	for _, attr := range []interface{}{uid, rid, sid, tid, prm, exp, gtm, uname} {
+		if attr == nil {
+			return authResultFail // response.Error(c, response.ErrNotPermitted, errors.New(msg))
+		}
+	}
+
+	prms, ok := prm.([]string)
+	if !ok {
+		return authResultFail // response.Error(c, response.ErrNotPermitted, nil)
+	}
+	if !lookupPerm(prms, privilegeInteractive) {
+		return authResultFail // response.Error(c, response.ErrNotPermitted, nil)
+	}
+	c.Set("prm", prms)
+
+	connectionType := p.connectionTypeRegexp.ReplaceAllString(c.Request.URL.Path, "$1")
+	switch connectionType {
+	case "aggregate", "browser", "external":
+	default:
+		connectionType = "browser"
+	}
+
+	c.Set("uid", uid.(uint64))
+	c.Set("rid", rid.(uint64))
+	c.Set("sid", sid.(uint64))
+	c.Set("tid", tid.(uint64))
+	c.Set("exp", exp.(int64))
+	c.Set("gtm", gtm.(int64))
+	c.Set("cpt", connectionType)
+	c.Set("uname", uname.(string))
+
+	return authResultOk
+}
+
+func (p *AuthMiddleware) tryProtoTokenAuthentication(c *gin.Context) authResult {
+	authHeader := c.Request.Header.Get("Authorization")
+	if authHeader == "" {
+		return authResultSkip // "token required"
+	}
+
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return authResultSkip // "must be used bearer schema"
+	}
+	token := authHeader[7:]
+	if token == "" {
+		return authResultSkip
+	}
+
+	claims, err := private.ValidateToken(token)
+	if err != nil {
+		return authResultFail // "token invalid"
+	}
+
+	c.Set("uid", claims.UID)
+	c.Set("rid", claims.RID)
+	c.Set("sid", claims.SID)
+	c.Set("tid", claims.TID)
+	c.Set("cpt", claims.CPT)
+	c.Set("prm", []string{privilegeInteractive})
+
+	c.Next()
+
+	return authResultOk
+}

--- a/pkg/app/api/server/middleware.go
+++ b/pkg/app/api/server/middleware.go
@@ -156,16 +156,16 @@ func authRequired() gin.HandlerFunc {
 	}
 }
 
+// localUserRequired checks that role of the caller is not External
+// This middleware must be used in the chain after authRequired.
 func localUserRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.IsAborted() {
 			return
 		}
 
-		session := sessions.Default(c)
-		rid := session.Get("rid")
-
-		if rid == nil || rid.(uint64) == models.RoleExternal {
+		roleID := c.GetUint64("rid")
+		if roleID == models.RoleExternal {
 			response.Error(c, response.ErrLocalUserRequired, nil)
 			return
 		}

--- a/pkg/app/api/server/middleware_test.go
+++ b/pkg/app/api/server/middleware_test.go
@@ -1,0 +1,334 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"soldr/pkg/app/api/models"
+	"soldr/pkg/app/api/server/private"
+	"soldr/pkg/app/api/storage"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthTokenProtoRequiredAuthWithCookie(t *testing.T) {
+	baseURL := "/api/v1"
+	testFunc := func() gin.HandlerFunc {
+		return authTokenProtoRequired(baseURL)
+	}
+	t.Run("test URL", func(t *testing.T) {
+		server := newTestServer(t, "/test", testFunc)
+		defer server.Close()
+
+		server.SetSessionCheckFunc(func(t *testing.T, c *gin.Context) {
+			t.Helper()
+			assert.Equal(t, uint64(1), c.GetUint64("uid"))
+			assert.Equal(t, uint64(2), c.GetUint64("rid"))
+			assert.Equal(t, uint64(4), c.GetUint64("sid"))
+			assert.Equal(t, uint64(3), c.GetUint64("tid"))
+			assert.Empty(t, c.GetString("svc"))
+			assert.NotNil(t, c.GetStringSlice("prm"))
+			assert.NotNil(t, c.GetInt64("gtm"))
+			assert.NotNil(t, c.GetInt64("exp"))
+			assert.Empty(t, c.GetString("uuid"))
+			assert.Equal(t, "browser", c.GetString("cpt"))
+			assert.Equal(t, "name1", c.GetString("uname"))
+		})
+
+		assert.False(t, server.CallAndGetStatus(t))
+
+		server.Authorize(t, []string{})
+		assert.False(t, server.CallAndGetStatus(t))
+
+		server.Authorize(t, []string{"wrong.permission"})
+		assert.False(t, server.CallAndGetStatus(t))
+
+		server.Authorize(t, []string{"vxapi.modules.interactive"})
+		assert.True(t, server.CallAndGetStatus(t))
+
+		server.Authorize(t, []string{"wrong.permission", "vxapi.modules.interactive"})
+		assert.True(t, server.CallAndGetStatus(t))
+	})
+
+	for _, kind := range []string{"aggregate", "browser", "external"} {
+		t.Run(kind+" URL", func(t *testing.T) {
+			server := newTestServer(t, baseURL+"/vxpws/"+kind+"/test", testFunc)
+			defer server.Close()
+
+			server.SetSessionCheckFunc(func(t *testing.T, c *gin.Context) {
+				t.Helper()
+				assert.Equal(t, kind, c.GetString("cpt"))
+			})
+			server.Authorize(t, []string{"vxapi.modules.interactive"})
+			assert.True(t, server.CallAndGetStatus(t))
+		})
+	}
+}
+
+func TestAuthTokenProtoRequiredAuthWithToken(t *testing.T) {
+	baseURL := "/api/v1"
+	testFunc := func() gin.HandlerFunc {
+		return authTokenProtoRequired(baseURL)
+	}
+
+	for _, kind := range []string{"aggregate", "browser", "external"} {
+		t.Run(kind+" type", func(t *testing.T) {
+
+			server := newTestServer(t, "/test", testFunc)
+			defer server.Close()
+
+			server.Authorize(t, []string{"vxapi.modules.interactive"})
+			token := server.GetToken(t, kind)
+			require.NotEmpty(t, token)
+
+			server.Unauthorize(t)
+			assert.False(t, server.CallAndGetStatus(t))
+
+			assert.False(t, server.CallAndGetStatus(t, token))
+			assert.False(t, server.CallAndGetStatus(t, "not a bearer "+token))
+			assert.False(t, server.CallAndGetStatus(t, "Bearer"+token))
+			assert.False(t, server.CallAndGetStatus(t, "Bearer not_a_token"))
+
+			server.SetSessionCheckFunc(func(t *testing.T, c *gin.Context) {
+				t.Helper()
+				assert.Equal(t, uint64(1), c.GetUint64("uid"))
+				assert.Equal(t, uint64(2), c.GetUint64("rid"))
+				assert.Equal(t, uint64(4), c.GetUint64("sid"))
+				assert.Equal(t, uint64(3), c.GetUint64("tid"))
+				assert.Empty(t, c.GetString("svc"))
+				assert.NotNil(t, c.GetStringSlice("prm"))
+				assert.Zero(t, c.GetInt64("gtm"))
+				assert.Zero(t, c.GetInt64("exp"))
+				assert.Empty(t, c.GetString("uuid"))
+				assert.Equal(t, kind, c.GetString("cpt"))
+				assert.Empty(t, c.GetString("uname"))
+			})
+
+			assert.True(t, server.CallAndGetStatus(t, "Bearer "+token))
+		})
+	}
+}
+
+func TestAuthRequiredAuthWithCookie(t *testing.T) {
+	server := newTestServer(t, "/test", authRequired)
+	defer server.Close()
+
+	server.SetSessionCheckFunc(func(t *testing.T, c *gin.Context) {
+		t.Helper()
+		assert.Equal(t, uint64(1), c.GetUint64("uid"))
+		assert.Equal(t, uint64(2), c.GetUint64("rid"))
+		assert.Equal(t, uint64(3), c.GetUint64("tid"))
+		assert.Equal(t, uint64(4), c.GetUint64("sid"))
+		assert.Equal(t, "svc1", c.GetString("svc"))
+		assert.NotNil(t, c.GetStringSlice("prm"))
+		assert.NotNil(t, c.GetInt64("gtm"))
+		assert.NotNil(t, c.GetInt64("exp"))
+		assert.Empty(t, c.GetString("uuid"))
+		assert.Equal(t, "name1", c.GetString("uname"))
+	})
+
+	assert.False(t, server.CallAndGetStatus(t))
+
+	server.Authorize(t, []string{"some.permission"})
+	assert.True(t, server.CallAndGetStatus(t))
+}
+
+type testServer struct {
+	testEndpoint     string
+	client           *http.Client
+	calls            map[string]struct{}
+	sessionCheckFunc func(t *testing.T, c *gin.Context)
+	*httptest.Server
+}
+
+func newTestServer(t *testing.T, testEndpoint string, middlewares ...func() gin.HandlerFunc) *testServer {
+	t.Helper()
+
+	server := &testServer{}
+
+	router := gin.New()
+	cookieStore := cookie.NewStore(storage.MakeCookieStoreKey())
+	router.Use(sessions.Sessions("auth", cookieStore))
+
+	server.calls = map[string]struct{}{}
+
+	if testEndpoint == "" {
+		testEndpoint = "/test"
+	}
+	server.testEndpoint = testEndpoint
+
+	router.GET("/auth", func(c *gin.Context) {
+		fmt.Println("AUTH ENDPOINT")
+		t.Helper()
+		privs, _ := c.GetQueryArray("privileges")
+		expString, ok := c.GetQuery("expiration")
+		assert.True(t, ok)
+		exp, err := strconv.Atoi(expString)
+		assert.NoError(t, err)
+		setTestSession(t, c, privs, exp)
+	})
+
+	authRoutes := router.Group("")
+	for _, middleware := range middlewares {
+		authRoutes.Use(middleware())
+	}
+	authRoutes.GET(server.testEndpoint, func(c *gin.Context) {
+		fmt.Println("TEST ENDPOINT")
+		t.Helper()
+		id, _ := c.GetQuery("id")
+		require.NotEmpty(t, id)
+
+		if server.sessionCheckFunc != nil {
+			server.sessionCheckFunc(t, c)
+		}
+		server.calls[id] = struct{}{}
+	})
+	authRoutes.GET("/auth_token", func(c *gin.Context) {
+		t.Helper()
+		cpt, ok := c.GetQuery("cpt")
+		assert.True(t, ok)
+		token, err := private.MakeToken(c, &models.ProtoAuthTokenRequest{
+			TTL:  3600,
+			Type: cpt,
+		})
+		require.NoError(t, err)
+		c.Writer.Write([]byte(token))
+	})
+
+	server.Server = httptest.NewServer(router)
+	server.client = server.Client()
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	server.client.Jar = jar
+
+	return server
+}
+
+func (s *testServer) Authorize(t *testing.T, privileges []string) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodGet, s.URL+"/auth", nil)
+	require.NoError(t, err)
+	query := url.Values{}
+	for _, p := range privileges {
+		query.Add("privileges", p)
+	}
+	query.Add("expiration", strconv.Itoa(5*60))
+	request.URL.RawQuery = query.Encode()
+
+	resp, err := s.client.Do(request)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func (s *testServer) GetToken(t *testing.T, cpt string) string {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodGet, s.URL+"/auth_token", nil)
+	require.NoError(t, err)
+	query := url.Values{}
+	query.Add("cpt", cpt)
+	request.URL.RawQuery = query.Encode()
+
+	resp, err := s.client.Do(request)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	token, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(token)
+}
+
+func (s *testServer) SetSessionCheckFunc(f func(t *testing.T, c *gin.Context)) {
+	s.sessionCheckFunc = f
+}
+
+func (s *testServer) Unauthorize(t *testing.T) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodGet, s.URL+"/auth", nil)
+	require.NoError(t, err)
+	query := url.Values{}
+	query.Add("expiration", strconv.Itoa(-1))
+	request.URL.RawQuery = query.Encode()
+
+	resp, err := s.client.Do(request)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func (s *testServer) TestCall(t *testing.T, token ...string) (string, bool) {
+	t.Helper()
+	id := strconv.Itoa(rand.Int())
+
+	request, err := http.NewRequest(http.MethodGet, s.URL+s.testEndpoint+"?id="+id, nil)
+	require.NoError(t, err)
+	if token != nil && len(token) == 1 {
+		request.Header.Add("Authorization", token[0])
+	}
+
+	resp, err := s.client.Do(request)
+	require.NoError(t, err)
+
+	assert.True(t, resp.StatusCode == http.StatusOK ||
+		resp.StatusCode == http.StatusForbidden)
+
+	return id, resp.StatusCode == http.StatusOK
+}
+
+func (s *testServer) TestCallWithData(t *testing.T, data string) (string, bool) {
+	t.Helper()
+	id := strconv.Itoa(rand.Int())
+
+	request, err := http.NewRequest(http.MethodGet, s.URL+s.testEndpoint+"?id="+id, bytes.NewBufferString(data))
+	require.NoError(t, err)
+
+	resp, err := s.client.Do(request)
+	require.NoError(t, err)
+
+	assert.True(t, resp.StatusCode == http.StatusOK ||
+		resp.StatusCode == http.StatusForbidden)
+
+	return id, resp.StatusCode == http.StatusOK
+}
+
+func (s *testServer) Called(id string) bool {
+	_, ok := s.calls[id]
+	return ok
+}
+
+func (s *testServer) CallAndGetStatus(t *testing.T, token ...string) bool {
+	t.Helper()
+	id, ok := s.TestCall(t, token...)
+	assert.Equal(t, ok, s.Called(id))
+	return ok
+}
+
+func setTestSession(t *testing.T, c *gin.Context, privileges []string, expires int) {
+	t.Helper()
+	session := sessions.Default(c)
+	session.Set("uid", uint64(1))
+	session.Set("rid", uint64(2))
+	session.Set("tid", uint64(3))
+	session.Set("sid", uint64(4))
+	session.Set("svc", "svc1")
+	session.Set("prm", privileges)
+	session.Set("gtm", time.Now().Unix())
+	session.Set("exp", time.Now().Add(time.Duration(expires)*time.Second).Unix())
+	session.Set("uuid", "uuid1")
+	session.Set("uname", "name1")
+	session.Options(sessions.Options{
+		HttpOnly: true,
+		MaxAge:   expires,
+	})
+	require.NoError(t, session.Save())
+}

--- a/pkg/app/api/server/permissions.go
+++ b/pkg/app/api/server/permissions.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 
@@ -13,14 +12,9 @@ import (
 )
 
 func getPrms(c *gin.Context) ([]string, error) {
-	session := sessions.Default(c)
-	prm := session.Get("prm")
-	if prm == nil {
-		return nil, fmt.Errorf("privileges is not set")
-	}
-	prms, ok := prm.([]string)
-	if !ok {
-		return nil, fmt.Errorf("privileges is malformed")
+	prms := c.GetStringSlice("prm")
+	if len(prms) == 0 {
+		return nil, fmt.Errorf("privileges are not set")
 	}
 	return prms, nil
 }

--- a/pkg/app/api/server/permissions_test.go
+++ b/pkg/app/api/server/permissions_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrivilegesRequiredPatchAgents(t *testing.T) {
+	server := newTestServer(t, "/test", authRequired, privilegesRequiredPatchAgents)
+	defer server.Close()
+
+	server.SetSessionCheckFunc(func(t *testing.T, c *gin.Context) {
+		t.Helper()
+		assert.Equal(t, uint64(1), c.GetUint64("uid"))
+	})
+
+	assert.False(t, server.CallAndGetStatus(t))
+
+	server.Authorize(t, []string{"some.permission"})
+	id, ok := server.TestCallWithData(t, "not a json")
+	assert.False(t, ok)
+	assert.False(t, server.Called(id))
+
+	server.Authorize(t, []string{"some.permission"})
+	id, ok = server.TestCallWithData(t, `{"action": "delete"}`)
+	assert.False(t, ok)
+	assert.False(t, server.Called(id))
+
+	server.Authorize(t, []string{"vxapi.agents.api.edit"})
+	id, ok = server.TestCallWithData(t, `{"action": "delete"}`)
+	assert.False(t, ok)
+	assert.False(t, server.Called(id))
+
+	server.Authorize(t, []string{"vxapi.agents.api.delete"})
+	id, ok = server.TestCallWithData(t, `{"action": "delete"}`)
+	assert.False(t, ok)
+	assert.True(t, server.Called(id))
+
+	for _, action := range []string{"authorize", "block", "delete", "unauthorize", "move"} {
+		server.Authorize(t, []string{"vxapi.agents.api.delete"})
+		id, ok = server.TestCallWithData(t, `{"action": "`+action+`"}`)
+		assert.False(t, ok)
+		assert.False(t, server.Called(id))
+
+		server.Authorize(t, []string{"vxapi.agents.api.edit"})
+		id, ok = server.TestCallWithData(t, `{"action": "`+action+`"}`)
+		assert.False(t, ok)
+		assert.True(t, server.Called(id))
+	}
+}
+
+func TestPrivilegesRequired(t *testing.T) {
+	privilegesMiddleware := func() gin.HandlerFunc {
+		return privilegesRequired("priv1", "priv2")
+	}
+	server := newTestServer(t, "/test", authRequired, privilegesMiddleware)
+	defer server.Close()
+
+	server.SetSessionCheckFunc(func(t *testing.T, c *gin.Context) {
+		t.Helper()
+		assert.Equal(t, uint64(1), c.GetUint64("uid"))
+	})
+
+	assert.False(t, server.CallAndGetStatus(t))
+
+	server.Authorize(t, []string{"some.permission"})
+	assert.False(t, server.CallAndGetStatus(t))
+
+	server.Authorize(t, []string{"priv1"})
+	assert.False(t, server.CallAndGetStatus(t))
+
+	server.Authorize(t, []string{"priv1", "priv2"})
+	assert.True(t, server.CallAndGetStatus(t))
+}

--- a/pkg/app/api/server/private/proto.go
+++ b/pkg/app/api/server/private/proto.go
@@ -71,7 +71,7 @@ func ValidateToken(tokenString string) (*models.ProtoAuthTokenClaims, error) {
 		return storage.MakeCookieStoreKey(), nil
 	})
 
-	if token.Valid {
+	if token != nil && token.Valid {
 		return &claims, nil
 	} else if ve, ok := err.(*jwt.ValidationError); ok {
 		if ve.Errors&jwt.ValidationErrorMalformed != 0 {

--- a/web/libs/features/modules-interactivity/src/lib/components/module-interactive-part/module-interactive-part.component.ts
+++ b/web/libs/features/modules-interactivity/src/lib/components/module-interactive-part/module-interactive-part.component.ts
@@ -136,7 +136,6 @@ export class ModuleInteractivePartComponent implements OnInit {
             vxHostPort = `ws://${window.location.host}`;
         }
 
-        console.log("on init interactive view", this.viewMode, this.viewMode === ViewMode.Agents, this.viewMode === ViewMode.Groups);
         if (this.viewMode === ViewMode.Agents) {
             protoAPI = new VXAPI({
                 hash: this.entity.hash,

--- a/web/libs/models/src/lib/agent.ts
+++ b/web/libs/models/src/lib/agent.ts
@@ -74,7 +74,7 @@ export const removeHashFromVersion = (version: string) => (version || '').replac
 export const canUpgradeAgent = (agent: Agent, latestBinaryVersion: string) =>
     agent?.auth_status === 'authorized' &&
     latestBinaryVersion &&
-    agent?.version !== removeHashFromVersion(latestBinaryVersion) &&
+    removeHashFromVersion(agent?.version) !== removeHashFromVersion(latestBinaryVersion) &&
     !['new', 'running', 'ready'].includes(agent.details?.upgrade_task?.status);
 
 export const isUpgradeAgentInProgress = (agent: Agent) =>


### PR DESCRIPTION
Idea of the PR is to cover auth middlewares with tests and group all middlewares into some object that can handle different auth chains for different use-cases.

### Description of the Change
- added tests that covers auth middlewares
- auth middlewares grouped into separate testable/extendable object

### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
