### PR TITLE
Remove second scrollbar on the modules-interactivity-part

### DIFF
--- a/web/libs/features/modules-interactivity/src/lib/components/module-page/module-page.component.html
+++ b/web/libs/features/modules-interactivity/src/lib/components/module-page/module-page.component.html
@@ -102,7 +102,6 @@
                     [tabId]="'management'">
                     <soldr-module-interactive-part
                         *ngIf="module && entity"
-                        class="layout-fill scrollable-y layout-padding-l"
                         [module]="module"
                         [entity]="entity"
                         [viewMode]="viewMode">


### PR DESCRIPTION
### Description of the Change
Remove the second scrollbars on the modules UI page.
 Closes #105

### How to test the Change

1. Create a new basic empty module
2. Install it into the policy
3. Open agent's view to modules UI.

### Changelog Entry
- Fixed scrollbars on modules UI page.


### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
